### PR TITLE
ncurses typing error solved with cast

### DIFF
--- a/getline.c
+++ b/getline.c
@@ -3928,7 +3928,7 @@ static int gl_print_control_sequence(GetLine *gl, int nline, const char *string)
 #if defined(USE_TERMINFO) || defined(USE_TERMCAP)
     tputs_gl = gl;
     errno = 0;
-    tputs((char *)string, nline, gl_tputs_putchar);
+    tputs((char *)string, nline, (int*) &gl_tputs_putchar);
     waserr = errno != 0;
 #else
     waserr = gl_print_raw_string(gl, 1, string, -1);


### PR DESCRIPTION
When building this library with macports, the following build error is generated:

```
:info:build make[1]: Entering directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_tecla/tecla/work/libtecla'
:info:build /usr/bin/clang -c -O  -DPACKAGE_NAME="" -DPACKAGE_TARNAME="" -DPACKAGE_VERSION="" -DPACKAGE_STRING="" -DPACKAGE_BUGREPORT="" -DPACKAGE_URL="" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DUSE_TERMINFO=1 -DHAVE_CURSES_H=1 -DHAVE_TERM_H=1 -DHAVE_SYS_SELECT_H=1 -DHAVE_SELECT=1 -DHAVE_SYSV_PTY=1 -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -arch arm64  -o normal_obj/getline.o ./getline.c
:info:build ./getline.c:3931:34: error: incompatible function pointer types passing 'TputsRetType (TputsArgType)' (aka 'void (int)') to parameter of type 'int (*)(int)' [-Wincompatible-function-pointer-types]
:info:build  3931 |     tputs((char *)string, nline, gl_tputs_putchar);
:info:build       |                                  ^~~~~~~~~~~~~~~~
:info:build /opt/local/include/term.h:848:60: note: passing argument to parameter here
:info:build   848 | extern NCURSES_EXPORT(int) tputs (const char *, int, int (*)(int));
:info:build       |                                                            ^
:info:build 1 error generated.
:info:build make[1]: *** [normal_obj/getline.o] Error 1
:info:build make[1]: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_tecla/tecla/work/libtecla'
:info:build make: *** [normal] Error 2
:info:build make: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_tecla/tecla/work/libtecla'
:info:build Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_tecla/tecla/work/libtecla" && /usr/bin/make -w default 
:info:build Exit code: 2
```

This provides a simple fix by type casting to the correct argument type.